### PR TITLE
fix: pkg.json main field should be a cjs file

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
       "import": "./dist/index.mjs"
     }
   },
-  "main": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "typesVersions": {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

pkg.main is an ESM file, but it is usually better to use pkg.exports instead, and remove pkg.main alongside, as compatible NodeJS version support it as well.
of course, we can also retain the `main` field, but we should use the cjs file.

if we don't fix this, it would cause some error at a time and it will not pass some check for example `publint` 


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
