### PR TITLE
chore: export package.json for higher version Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
### Description

I think maybe we should also add this export to the template. Yesterday, I saw a project called magic-string-stack that seemed to have the same issue. So, I thought maybe the template hasn't been updated in a timely manner.

### Linked Issues

shikijs/shiki#640

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
